### PR TITLE
Fixes from PoolOfThought Fork - help, linux console, suppress warnings directive

### DIFF
--- a/CSProlog/Engine.cs
+++ b/CSProlog/Engine.cs
@@ -1808,7 +1808,8 @@ namespace Prolog
 #if NETSTANDARD
           if (enablePersistence)
           {
-            throw new NotImplementedException();
+            //TODO: enable persistence
+            //throw new NotImplementedException();
           }
 #else
           if (enablePersistence)

--- a/CSProlog/Engine.cs
+++ b/CSProlog/Engine.cs
@@ -510,6 +510,7 @@ namespace Prolog
     bool findFirstClause; // find the first clause of predicate that matches the current goal goal (-last head)
     bool csharpStrings = ConfigSettings.CSharpStrings;
     bool userSetShowStackTrace = ConfigSettings.OnErrorShowStackTrace; // default value
+    bool showSingletonWarnings = true; // want to be able to turn off singleton warnings at the file level (default to true and will need to add to reset code to make sure it isn't persisting across files)
 
     #region unique number generators
     static int unifyCount; // total number of unifications - for tabling ('cost calculation') only
@@ -2026,7 +2027,7 @@ namespace Prolog
     }
 
     public void ReportSingletons (ClauseNode c, int lineNo, ref bool firstReport)
-    {
+    {  
       solution.ReportSingletons (c, lineNo, ref firstReport);
     }
     #endregion Named variables

--- a/CSProlog/PG/PL.cs
+++ b/CSProlog/PG/PL.cs
@@ -399,7 +399,11 @@ namespace Prolog
             }
           }
           c = new ClauseNode (head, body);
-          engine.ReportSingletons (c, lineNo - 1, ref firstReport);
+
+          if (engine.showSingletonWarnings)
+          {
+            engine.ReportSingletons(c, lineNo - 1, ref firstReport);
+          }
           ps.AddClause (c);
         }
         else if (symbol.TerminalId == PromptSym)

--- a/CSProlog/PredStorage.cs
+++ b/CSProlog/PredStorage.cs
@@ -830,10 +830,25 @@ namespace Prolog
       public bool ShowHelp (string functor, int arity, out string suggestion)
       {
         suggestion = null;
-        const string HELPRES = "CsProlog.CsPrologHelp";
+        string HELPRES = "CsProlog.CsPrologHelp"; // default HELPRES
 
-        Assembly asm = Assembly.Load(new AssemblyName(GetType().AssemblyQualifiedName));
-        //string [] res = asm.GetManifestResourceNames (); // pick the right functor from res and put in in HELPRES
+        Assembly asm = Assembly.Load(new AssemblyName("CSProlog"));
+
+        //TODO: I've hardcoded the assembly name is CSProlog in Assembly.Load rather than using the AssemblyQualifiedName (was getting an error - not sure why and don't want to fight with it)
+        //Assembly asm = Assembly.Load(new AssemblyName(GetType().AssemblyQualifiedName));
+
+        string [] res = asm.GetManifestResourceNames (); // pick the right functor from res and put in in HELPRES
+        foreach (string s in res)
+        {
+            //IO.WriteLine("FunctorInGetManifestResourceNames: " + s); // uncomment to see the resources - maybe help identify which one it should be if having problmes
+            //Could be CSProlog.CSPrologHelp.resources  OR  CSProlog.Core.CSPrologHelp.resources --- the below loop should find the right one and user it
+            if (s.Contains("CsPrologHelp.resources"))
+            {
+              HELPRES = s.Replace(".resources", "");
+              break;
+            }
+        }
+
         ResourceManager rm = new ResourceManager (HELPRES, asm);
 
         if (functor == null)
@@ -841,8 +856,8 @@ namespace Prolog
           IO.WriteLine (rm.GetString ("help$"));
           IO.WriteLine ("\r\n  (*) contains the description of a feature rather than a predicate.");
           IO.WriteLine ("\r\n  Usage: help <predicate>[/<arity>] or help( <predicate>[/<arity>]).");
-          IO.WriteLine ("\r\n  File CsPrologHelp.txt contains the help texts and a description of how to re-create help.");
-
+          IO.WriteLine ("\r\n  File CsPrologHelp.txt contains the help texts and a description of how to re-create help."); //TODO: I can't seem to find this file. Eliminate the line or create the file???
+      
           return true;
         }
         else if (functor == "history")

--- a/CSProlog/PredStorage.cs
+++ b/CSProlog/PredStorage.cs
@@ -867,8 +867,7 @@ namespace Prolog
           IO.WriteLine ("\r\n  (*) contains the description of a feature rather than a predicate.");
           IO.WriteLine ("\r\n  Usage: help <predicate>[/<arity>] or help( <predicate>[/<arity>]).");
           IO.WriteLine ("\r\n  File CsPrologHelp.txt contains the help texts and a description of how to re-create help."); //TODO: I can't seem to find this file. Eliminate the line or create the file???
-          IO.WriteLine("\r\n  Facts must be read from a file before they can be queried. try  help(consult). to see how to read in from a file.");
-
+          
           return true;
         }
         else if (functor == "history")

--- a/CSProlog/PredStorage.cs
+++ b/CSProlog/PredStorage.cs
@@ -261,8 +261,8 @@ namespace Prolog
         PrologParser parser = Globals.CurrentParser = new PrologParser (engine);
         allDiscontiguous = false;
 
-        try
-        {
+       try
+       {
           prevIndex = null;
           definedInCurrFile.Clear ();
           isDiscontiguous.Clear ();
@@ -276,7 +276,9 @@ namespace Prolog
         }
         finally
         {
-          Globals.CurrentParser = consultParserStack.Pop (); ;
+        engine.showSingletonWarnings = true; // set it back to the default value of true
+
+        Globals.CurrentParser = consultParserStack.Pop (); ;
           //Globals.ConsultModuleName = null; // Currently not used
         }
 
@@ -355,7 +357,15 @@ namespace Prolog
            else
               IO.Error (":- stacktrace: illegal argument '{0}'; use 'on' or 'off' instead", argument);
             break;
-          case "initialization":
+          case "style_check_singleton_warning":
+            if (argument == "on")
+                engine.showSingletonWarnings = true;
+            else if (argument == "off")
+                engine.showSingletonWarnings = false;
+            else
+                IO.Error(":- style_check_singleton_warning: illegal argument '{0}'; use 'on' or 'off' instead. It is 'on' by default.", argument);
+            break;
+                    case "initialization":
             IO.Warning ("':- initialization' directive not implemented -- ignored");
             break;
           default:
@@ -857,7 +867,8 @@ namespace Prolog
           IO.WriteLine ("\r\n  (*) contains the description of a feature rather than a predicate.");
           IO.WriteLine ("\r\n  Usage: help <predicate>[/<arity>] or help( <predicate>[/<arity>]).");
           IO.WriteLine ("\r\n  File CsPrologHelp.txt contains the help texts and a description of how to re-create help."); //TODO: I can't seem to find this file. Eliminate the line or create the file???
-      
+          IO.WriteLine("\r\n  Facts must be read from a file before they can be queried. try  help(consult). to see how to read in from a file.");
+
           return true;
         }
         else if (functor == "history")

--- a/PL.NETcore/Main.cs
+++ b/PL.NETcore/Main.cs
@@ -1,0 +1,143 @@
+/*-----------------------------------------------------------------------------------------
+
+  C#Prolog -- Copyright (C) 2007-2014 John Pool -- j.pool@ision.nl
+
+  This library is free software; you can redistribute it and/or modify it under the terms of
+  the GNU General Public License as published by the Free Software Foundation; either version
+  2 of the License, or any later version.
+
+  This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU General Public License for details, or enter 'license.' at the command prompt.
+
+-------------------------------------------------------------------------------------------*/
+
+using System;
+using System.Text;
+using System.Runtime.InteropServices;
+
+namespace Prolog
+{
+  class PrologParser
+  {
+    [STAThread]
+    public static void Main (string [] args)
+    {
+      PrologEngine e = null;
+
+      try
+      {
+        e = new PrologEngine (new DosIO ());
+
+        // ProcessArgs -- for batch processing. Can be left out if not used
+        //if (e.ProcessArgs (args, false)) return;
+
+        SetPreferredConsoleProperties (e);
+        Console.Title = "C#Prolog command window";
+        Console.WriteLine (PrologEngine.IntroText);
+        Console.WriteLine ("\r\n--- Enter !! for command history, help for a list of all commands");
+
+        //if (Engine.ConfigSettings.InitialConsultFile != null)   // set in CSProlog.exe.config
+        //  e.Consult (Engine.ConfigSettings.InitialConsultFile); // any additional initialisations
+
+        while (!e.Halted)
+        {
+          Console.Write (e.Prompt);
+          e.Query = ReadQuery ();
+          
+          // Use e.GetFirstSolution instead of the loop below if you want the first solution only.
+          //Console.Write (e.GetFirstSolution (e.Query));
+
+          foreach (PrologEngine.ISolution s in e.SolutionIterator)
+          {
+            // In order to get the individual variables:
+            //foreach (Engine.IVarValue varValue in s.VarValuesIterator)
+            // { Console.WriteLine (varValue.Value.To<int> ()); } // or ToString () etc.
+            Console.Write (s);
+
+            if (s.IsLast || !UserWantsMore ()) break;
+          }
+
+          Console.WriteLine ();
+        }
+      }
+      catch (Exception x)
+      {
+        Console.WriteLine ("Error while initializing Prolog Engine. Message was:\r\n{0}",
+          x.GetBaseException ().Message + Environment.NewLine + x.StackTrace);
+          Console.ReadLine ();
+      }
+      finally
+      {
+        if (e != null) e.PersistCommandHistory (); // cf. CSProlog.exe.config
+      }
+    }
+
+
+    #region Console I/O
+    static void SetPreferredConsoleProperties (PrologEngine e)
+    {
+      Console.ForegroundColor = ConsoleColor.DarkBlue;
+      Console.BackgroundColor = ConsoleColor.White;
+      Console.Clear (); // applies the background color to the *entire* window background
+      
+      if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+      {
+        try{Console.WindowWidth = 140;}catch{  }
+        try{Console.WindowHeight = 60;}catch{  }
+        try{Console.BufferWidth = 140;}catch{  }  
+        try{Console.BufferHeight = 3000;}catch{  }
+        try{Console.WindowTop = 0;}catch{  }
+        try{Console.WindowLeft = 0;}catch{  }
+      }
+      
+      // TODO: The following line is supposed to prevent ^C from exiting the application - it doesn't work for linux
+      Console.CancelKeyPress += new ConsoleCancelEventHandler (e.Console_CancelKeyPress);
+    }
+
+    static string ReadQuery ()
+    {
+      StringBuilder sb = new StringBuilder ();
+      string line;
+
+      while (true)
+      {
+        if ((line = System.ReadLine.Read()) == null)
+        {
+          sb.Length = 0;
+
+          break;
+        }
+        else
+        {
+          sb.AppendLine (line);
+
+          if (line.EndsWith ("/") || line.StartsWith ("!") || line.EndsWith (".")) 
+            break;
+
+          Console.Write ("|  ");
+        }
+      }
+
+      ReadLine.AddHistory(sb.ToString().TrimEnd( Environment.NewLine.ToCharArray()));
+      return sb.ToString ();
+    }
+
+
+    static bool UserWantsMore ()
+    {
+      Console.Write ("  more? (y/n) ");
+      char response = Console.ReadKey ().KeyChar;
+
+      if (response == 'y' || response == ';')
+      {
+        Console.WriteLine ();
+
+        return true;
+      }
+
+      return false;
+    }
+    #endregion
+  }
+}

--- a/PL.NETcore/PL.NETcore.csproj
+++ b/PL.NETcore/PL.NETcore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <StartupObject>
+    </StartupObject>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CSProlog\CSProlog.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" />
+    <PackageReference Include="ReadLine" Version="2.0.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixed help bug (#5).

Added a linux console app project. Includes library ReadLine to give bash like command history.

Added a directive that when used will suppress warnings related to Singletons when consulting a file. Can be toggled on and off during a file's processing.

